### PR TITLE
Gallery detail head tv layout

### DIFF
--- a/app/src/main/res/layout-television/gallery_detail_actions.xml
+++ b/app/src/main/res/layout-television/gallery_detail_actions.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2016 Hippo Seven
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/actions"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/keyline_margin">
+
+    <TextView
+        android:id="@+id/newerVersion"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:gravity="center"
+        android:padding="8dp"
+        android:text="@string/newer_version_avaliable"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingLeft="@dimen/keyline_margin"
+        android:paddingRight="@dimen/keyline_margin">
+
+
+        <LinearLayout
+            android:id="@+id/rate"
+            android:layout_width="484dp"
+            android:layout_height="wrap_content"
+            android:background="?selectableItemBackground"
+            android:orientation="vertical"
+            android:paddingTop="8dp"
+            android:paddingBottom="8dp">
+
+            <androidx.appcompat.widget.AppCompatRatingBar
+                android:id="@+id/rating"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="0dp"
+                android:layout_marginTop="0dp"
+
+                android:isIndicator="true"
+                android:theme="@style/RatingBarTheme" />
+
+            <TextView
+                android:id="@+id/rating_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginLeft="0dp"
+                android:textColor="?android:attr/textColorPrimary" />
+
+        </LinearLayout>
+
+        <HorizontalScrollView
+            android:id="@+id/actions_scroll_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:clipToPadding="false"
+            android:paddingLeft="36dp"
+            android:paddingRight="@dimen/keyline_margin"
+            android:scrollbars="none">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:divider="@drawable/spacer_keyline"
+                android:orientation="horizontal"
+                android:showDividers="middle">
+
+                <FrameLayout
+                    android:id="@+id/heart_group"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:nextFocusUp="@+id/download">
+
+                    <TextView
+                        android:id="@+id/heart"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:drawablePadding="4dp"
+                        android:gravity="center_horizontal"
+                        android:text="@string/favorited"
+                        android:textColor="?android:attr/textColorPrimary" />
+
+                    <TextView
+                        android:id="@+id/heart_outline"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:drawablePadding="4dp"
+                        android:gravity="center_horizontal"
+                        android:text="@string/not_favorited"
+                        android:textColor="?android:attr/textColorPrimary" />
+
+                </FrameLayout>
+
+                <TextView
+                    android:id="@+id/share"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:drawablePadding="4dp"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:nextFocusUp="@+id/download"
+                    android:text="@string/share"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <TextView
+                    android:id="@+id/torrent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:drawablePadding="4dp"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:nextFocusUp="@+id/download"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <TextView
+                    android:id="@+id/archive"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:drawablePadding="4dp"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:nextFocusUp="@+id/download"
+                    android:text="@string/archive"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <TextView
+                    android:id="@+id/similar"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:drawablePadding="4dp"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:nextFocusUp="@+id/download"
+                    android:text="@string/similar_gallery"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <TextView
+                    android:id="@+id/search_cover"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?selectableItemBackgroundBorderless"
+                    android:clickable="true"
+                    android:drawablePadding="4dp"
+                    android:focusable="true"
+                    android:gravity="center_horizontal"
+                    android:nextFocusRight="@+id/search_cover"
+                    android:nextFocusUp="@+id/download"
+                    android:text="@string/search_cover"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+            </LinearLayout>
+        </HorizontalScrollView>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout-television/gallery_detail_actions.xml
+++ b/app/src/main/res/layout-television/gallery_detail_actions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2016 Hippo Seven
+  ~ Copyright 2022 hathlife
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-television/gallery_detail_actions.xml
+++ b/app/src/main/res/layout-television/gallery_detail_actions.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout-television/gallery_detail_header.xml
+++ b/app/src/main/res/layout-television/gallery_detail_header.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2015 Hippo Seven
+  ~ Copyright 2022 hathlife
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout-television/gallery_detail_header.xml
+++ b/app/src/main/res/layout-television/gallery_detail_header.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2015 Hippo Seven
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/color_bg"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:elevation="4dp"
+            app:fitsSystemWindowsInsets="top" />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="28dp" />
+
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/title"
+            style="@style/TextAppearance.Material3.HeadlineSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/keyline_margin"
+            android:layout_marginRight="@dimen/keyline_margin"
+            android:ellipsize="end"
+            android:maxLines="5" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.card.MaterialCardView
+                style="@style/Widget.Material3.CardView.Elevated"
+                android:layout_width="540dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/keyline_margin"
+                android:layout_marginTop="@dimen/keyline_margin"
+                android:layout_marginRight="@dimen/keyline_margin"
+                android:layout_marginBottom="@dimen/keyline_margin"
+                app:fitsSystemWindowsInsets="top">
+
+
+                <RelativeLayout
+                    android:id="@+id/header_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/thumb_card"
+                        style="@style/Widget.Material3.CardView.Elevated"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content">
+
+                        <com.hippo.widget.LoadImageView
+                            android:id="@+id/thumb"
+                            android:layout_width="256dp"
+                            android:layout_height="@dimen/gallery_detail_thumb_height" />
+
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.card.MaterialCardView
+                        android:id="@+id/info"
+                        style="@style/Widget.Material3.CardView.Filled"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_marginTop="8dp"
+                        android:layout_marginEnd="@dimen/keyline_margin"
+                        android:clickable="true"
+                        android:focusable="true"
+                        android:nextFocusRight="@+id/read"
+                        android:orientation="vertical">
+
+                        <TableLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:padding="8dp">
+
+                            <TableRow>
+
+                                <TextView
+                                    android:id="@+id/language"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:gravity="left"
+                                    android:singleLine="true" />
+
+                                <TextView
+                                    android:id="@+id/size"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:gravity="right"
+                                    android:singleLine="true" />
+
+                            </TableRow>
+
+                            <TableRow android:paddingTop="8dp">
+
+                                <TextView
+                                    android:id="@+id/favoredTimes"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:gravity="left"
+                                    android:singleLine="true" />
+
+                                <TextView
+                                    android:id="@+id/pages"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:gravity="right"
+                                    android:singleLine="true" />
+
+                            </TableRow>
+
+                            <TableRow android:paddingTop="8dp">
+
+                                <TextView
+                                    android:id="@+id/posted"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_weight="1"
+                                    android:gravity="left"
+                                    android:singleLine="true" />
+
+                            </TableRow>
+                        </TableLayout>
+
+                    </com.google.android.material.card.MaterialCardView>
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/uploader"
+                        style="@style/Widget.Material3.Chip.Assist"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignBottom="@id/thumb_card"
+                        android:layout_alignParentEnd="true"
+                        android:layout_marginEnd="@dimen/keyline_margin"
+                        android:ellipsize="end"
+                        android:nextFocusRight="@+id/read"
+                        android:nextFocusDown="@+id/rate"
+                        android:singleLine="true"
+                        android:textAllCaps="true"
+                        app:chipIcon="@drawable/file_upload_black_24dp"
+                        app:ensureMinTouchTargetSize="true" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/category"
+                        style="@style/Widget.Material3.Chip.Assist"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_above="@id/uploader"
+                        android:layout_alignParentEnd="true"
+                        android:layout_marginEnd="@dimen/keyline_margin"
+                        android:ellipsize="end"
+                        android:singleLine="true"
+                        android:textAllCaps="true"
+                        app:chipIcon="@drawable/ic_baseline_label_24"
+                        app:ensureMinTouchTargetSize="true"
+                        android:nextFocusRight="@+id/read" />
+
+                </RelativeLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:id="@+id/action_card"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/keyline_margin"
+                android:layout_marginRight="@dimen/keyline_margin"
+                android:orientation="vertical">
+
+                <Button
+                    android:id="@+id/read"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:insetLeft="40dp"
+                    android:insetRight="40dp"
+                    android:insetTop="16dp"
+                    android:text="@string/read">
+
+                    <requestFocus />
+                </Button>
+
+                <Button
+                    android:id="@+id/download"
+                    style="@style/Widget.Material3.Button.TonalButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:clickable="true"
+                    android:nextFocusDown="@+id/torrent"
+                    android:focusable="true"
+                    android:insetLeft="40dp"
+                    android:insetTop="16dp"
+                    android:insetRight="40dp" />
+
+
+                <android.widget.Space
+                    android:layout_width="match_parent"
+                    android:layout_height="80dp" />
+
+
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout-television/gallery_detail_header.xml
+++ b/app/src/main/res/layout-television/gallery_detail_header.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout-television/scene_cookie_sign_in.xml
+++ b/app/src/main/res/layout-television/scene_cookie_sign_in.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout-television/scene_login.xml
+++ b/app/src/main/res/layout-television/scene_login.xml
@@ -36,7 +36,7 @@
 
             <ImageView
                 android:layout_width="257dp"
-                android:layout_height="518dp"
+                android:layout_height="match_parent"
                 android:layout_gravity="center_horizontal"
                 android:padding="@dimen/keyline_margin"
                 app:srcCompat="@mipmap/ic_launcher" />

--- a/app/src/main/res/layout-television/scene_login.xml
+++ b/app/src/main/res/layout-television/scene_login.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout-television/scene_select_site.xml
+++ b/app/src/main/res/layout-television/scene_select_site.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout-television/scene_warning.xml
+++ b/app/src/main/res/layout-television/scene_warning.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2022 hathlife
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ This file is part of EhViewer
   ~
-  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~ EhViewer is free software: you can redistribute it and/or
+  ~ modify it under the terms of the GNU General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ EhViewer is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+  ~ or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with EhViewer.
+  ~ If not, see <https://www.gnu.org/licenses/>.
+  ~
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
* Set ```<requsetFocus />``` for read button, make it able to press immediately after entered the scene.
* Add several ```android:nextFocus*```  for views to make better dpad navigation
* Change aspect ratio of cover thumb to 4:3 (256dp*192dp), both good for TV UX & display of thumb of *CG gallery covers
* Use GPLv3 for all current code of TV layout
Test device: TCL 50C725 Google TV 11
![image](https://user-images.githubusercontent.com/19867269/179380665-4b40cc79-0b7e-4693-b0a5-0f7d7d2b058c.png)
