### PR TITLE
Add Gradle cache clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Gradle Build
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-home-cache-cleanup: true
           arguments: assembleRelease
 
       - name: Update ARM64


### PR DESCRIPTION
To prevent the Gradle cache from growing without limit.