### PR TITLE
Fix toplist page load

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryListScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryListScene.java
@@ -492,6 +492,8 @@ public final class GalleryListScene extends BaseScene
             mFabLayout.getSecondaryFabAt(0).setImageResource(isTopList ? R.drawable.ic_baseline_format_list_numbered_24 : R.drawable.v_magnify_x24);
         }
 
+        mFabLayout.setSecondaryFabVisibilityAt(1, ListUrlBuilder.MODE_WHATS_HOT != builder.getMode());
+
         // Update normal search mode
         mSearchLayout.setNormalSearchMode(builder.getMode() == ListUrlBuilder.MODE_SUBSCRIPTION
                 ? R.id.search_subscription_search

--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryListScene.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/GalleryListScene.java
@@ -25,6 +25,7 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.text.InputType;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -859,14 +860,47 @@ public final class GalleryListScene extends BaseScene
             return;
         }
 
-        var datePicker = MaterialDatePicker.Builder.datePicker()
-                .setTitleText(R.string.go_to)
-                .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
-                .build();
-        datePicker.show(requireActivity().getSupportFragmentManager(), "date-picker");
-        datePicker.addOnPositiveButtonClickListener(v -> {
-            mHelper.goTo(v);
-        });
+        if (ListUrlBuilder.MODE_TOPLIST == mUrlBuilder.getMode()) {
+            final int page = (mHelper.getPageForTop() == 0 ? mHelper.pgCounter : mHelper.getPageForTop()) + 1;
+            final int pages = 200;
+            String hint = getString(R.string.go_to_hint, page, pages);
+            final EditTextDialogBuilder builder = new EditTextDialogBuilder(context, null, hint);
+            builder.getEditText().setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+            final AlertDialog dialog = builder.setTitle(R.string.go_to)
+                    .setPositiveButton(android.R.string.ok, null)
+                    .show();
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
+                if (null == mHelper) {
+                    dialog.dismiss();
+                    return;
+                }
+
+                String text = builder.getText().trim();
+                int goTo;
+                try {
+                    goTo = Integer.parseInt(text);
+                } catch (NumberFormatException e) {
+                    builder.setError(getString(R.string.error_invalid_number));
+                    return;
+                }
+                if (goTo <= 0 || goTo > pages) {
+                    builder.setError(getString(R.string.error_out_of_range));
+                    return;
+                }
+                builder.setError(null);
+                mHelper.goToPage(goTo);
+                dialog.dismiss();
+            });
+        } else {
+            var datePicker = MaterialDatePicker.Builder.datePicker()
+                    .setTitleText(R.string.go_to)
+                    .setSelection(MaterialDatePicker.todayInUtcMilliseconds())
+                    .build();
+            datePicker.show(requireActivity().getSupportFragmentManager(), "date-picker");
+            datePicker.addOnPositiveButtonClickListener(v -> {
+                mHelper.goTo(v);
+            });
+        }
     }
 
     @Override
@@ -1702,11 +1736,17 @@ public final class GalleryListScene extends BaseScene
             }
 
             if (page != 0)
-                mUrlBuilder.setNextGid(minGid);
+                mUrlBuilder.setNextGid(mIsTopList ? page : minGid);
             else
                 mUrlBuilder.setNextGid(0);
+
+            if (jumpTo != null && mIsTopList) {
+                pgCounter = Integer.parseInt(jumpTo) - 1;
+                mUrlBuilder.setNextGid(pgCounter);
+            }
             mUrlBuilder.setJumpTo(jumpTo);
             jumpTo = null;
+
             if (ListUrlBuilder.MODE_IMAGE_SEARCH == mUrlBuilder.getMode()) {
                 EhRequest request = new EhRequest();
                 request.setMethod(EhClient.METHOD_IMAGE_SEARCH);

--- a/app/src/main/java/com/hippo/ehviewer/widget/GalleryInfoContentHelper.kt
+++ b/app/src/main/java/com/hippo/ehviewer/widget/GalleryInfoContentHelper.kt
@@ -127,6 +127,11 @@ abstract class GalleryInfoContentHelper : ContentHelper<GalleryInfo?>() {
         doRefresh()
     }
 
+    fun goToPage(page: Int) {
+        jumpTo = page.toString()
+        doRefresh()
+    }
+
     companion object {
         private const val KEY_DATA_MAP = "data_map"
         private const val KEY_MAX_GID = "max_gid"


### PR DESCRIPTION
1. 移除了“热门”页面的跳页按钮，该页面本来就只有一页
2. 修复了“排行”页面的翻页与跳页，由于该页面为表站页面，跳页逻辑暂时仍使用原来的