### PR TITLE
Fix "Unable to load PublicSuffixDatabase.gz"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,7 +70,6 @@ android {
     packagingOptions {
         resources {
             excludes += "/META-INF/**"
-            excludes += "/okhttp3/**"
             excludes += "/kotlin/**"
             excludes += "**.txt"
             excludes += "**.bin"


### PR DESCRIPTION
当初为啥要排除掉