### PR TITLE
Apply advance search in keyword

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/data/ListUrlBuilder.kt
+++ b/app/src/main/java/com/hippo/ehviewer/client/data/ListUrlBuilder.kt
@@ -283,13 +283,6 @@ data class ListUrlBuilder(
                 if (this.category != EhUtils.NONE) {
                     ub.addQuery("f_cats", category.inv() and EhConfig.ALL_CATEGORY)
                 }
-                // Search key
-                mKeyword?.run {
-                    val keyword = trim { it <= ' ' }
-                    if (keyword.isNotEmpty()) {
-                        ub.addQuery("f_search", encodeUTF8(this))
-                    }
-                }
                 mSHash?.let {
                     ub.addQuery("f_shash", it)
                 }
@@ -301,6 +294,19 @@ data class ListUrlBuilder(
                 }
                 mNext?.let {
                     ub.addQuery("next", it)
+                }
+                // Search key 
+                // the settings of ub:UrlBuilder may be overwritten by following Advance search
+                StringUtils.split(mKeyword, '|')?.forEachIndexed { idx, keyword ->
+                    val keyword = keyword.trim { it <= ' ' }
+                    when (idx) {
+                        0 -> keyword.takeIf { it.isNotEmpty() }?.let { ub.addQuery("f_search", encodeUTF8(it)) }
+                        else -> keyword.indexOf(':').takeIf { it >= 0 }?.run {
+                            val key = keyword.substring(0, this).trim { it <= ' ' }
+                            val value = keyword.substring(this + 1).trim { it <= ' ' }
+                            ub.addQuery(key, encodeUTF8(value))
+                        }
+                    }
                 }
                 // Advance search
                 if (advanceSearch != -1) {


### PR DESCRIPTION
可以通过在搜索框输入 `rawKeyword | key1:value1 | key2:value2` 的方式来设置url。
<br/>


举例： 如果我想搜索`星之迟迟`的隐藏画廊
+ 现有的操作是：
  + 搜索框输入`cosplayer:hoshilily$`
  + 点击`+`号
  + 勾选`启用高级选项`
  + 勾选`仅显示被删除的画廊`
  + 搜索

  + 如果后续想要复现这一操作：
    - [ ] ~~通过点击搜索框的输入历史~~
    - [x]  保存到快速搜索

+ 对于现有的patch：
  + 搜索框输入`cosplayer:hoshilily$ | advsearch:1 | f_sh:on`   
      好像去掉advsearch也行：  `cosplayer:hoshilily$ | f_sh:on`
  + 搜索
  + 如果后续想要复现这一操作：
    - [x] 通过点击搜索框的输入历史
    - [x]  保存到快速搜索

兼容现有操作(在keyword没有`|`的情况下)