### PR TITLE
Use .jpg instead of .jpeg for image/jpeg

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/gallery/PageLoader2.java
+++ b/app/src/main/java/com/hippo/ehviewer/gallery/PageLoader2.java
@@ -28,7 +28,6 @@ public abstract class PageLoader2 extends PageLoader {
     // With dot
     public static final String[] SUPPORT_IMAGE_EXTENSIONS = {
             ".jpg", // Joint Photographic Experts Group
-            ".jpeg",
             ".png", // Portable Network Graphics
             ".gif", // Graphics Interchange Format
     };

--- a/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueenWorker.kt
+++ b/app/src/main/java/com/hippo/ehviewer/spider/SpiderQueenWorker.kt
@@ -112,7 +112,6 @@ class SpiderQueenWorker(private val queen: SpiderQueen) : CoroutineScope {
             return queen.updatePageState(index, STATE_FINISHED)
         }
         if (force) {
-            spiderDen.remove(index)
             pTokenLock.withLock {
                 val pToken = spiderInfo.pTokenMap[index]
                 if (pToken == TOKEN_FAILED) spiderInfo.pTokenMap.remove(index)


### PR DESCRIPTION
No need to delete old files since it will check if the file already exists here.
https://github.com/Ehviewer-Overhauled/Ehviewer/blob/d7b08a018141cd6b2a9cd1d812f12dc1c1d8e582/app/src/main/java/com/hippo/unifile/TreeDocumentFile.java#L54-L59
The reason it gets recreated is because the `displayName` passed to `createFile()` is different from the actual created filename created.
https://github.com/Ehviewer-Overhauled/Ehviewer/blob/300505e127e569c38adf676b91aa99461877ae2d/app/src/main/java/com/hippo/ehviewer/spider/SpiderDen.kt#L175
We use the subtype of content type if it's in `SUPPORT_IMAGE_EXTENSIONS`, thus `.jpeg` for `image/jpeg` while `DocumentsContract.createDocument()` uses `.jpg`