### PR TITLE
Revert "Workaround #1065"

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/ui/scene/BaseScene.kt
+++ b/app/src/main/java/com/hippo/ehviewer/ui/scene/BaseScene.kt
@@ -29,11 +29,12 @@ import androidx.core.view.SoftwareKeyboardControllerCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.Fragment
 import com.hippo.ehviewer.ui.MainActivity
+import com.hippo.ehviewer.util.getSparseParcelableArrayCompat
 import rikka.core.res.resolveDrawable
 
 abstract class BaseScene : Fragment() {
     private var drawerView: View? = null
-    private var drawerViewState: SparseArray<Parcelable?>? = null
+    private var drawerViewState: SparseArray<Parcelable>? = null
     fun addAboveSnackView(view: View) {
         val activity = activity
         if (activity is MainActivity) {
@@ -120,7 +121,7 @@ abstract class BaseScene : Fragment() {
         if (drawerView != null) {
             var saved = drawerViewState
             if (saved == null && savedInstanceState != null) {
-                saved = savedInstanceState.getSparseParcelableArray(KEY_DRAWER_VIEW_STATE)
+                saved = savedInstanceState.getSparseParcelableArrayCompat(KEY_DRAWER_VIEW_STATE)
             }
             if (saved != null) {
                 drawerView!!.restoreHierarchyState(saved)

--- a/app/src/main/java/com/hippo/ehviewer/util/ParcelableCompat.kt
+++ b/app/src/main/java/com/hippo/ehviewer/util/ParcelableCompat.kt
@@ -1,18 +1,11 @@
-@file:Suppress("DEPRECATION")
-
 package com.hippo.ehviewer.util
 
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
 
-// inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String?): T? = BundleCompat.getParcelable(this, key, T::class.java)
-// inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String?): ArrayList<T>? = BundleCompat.getParcelableArrayList(this, key, T::class.java)
-// inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String?): T? = IntentCompat.getParcelableExtra(this, key, T::class.java)
-
-// Avoid using new API on Tiramisu
-// See https://issuetracker.google.com/issues/240585930 & https://github.com/Ehviewer-Overhauled/Ehviewer/issues/1065
-
-inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String?): T? = getParcelable(key)
-inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String?): ArrayList<T>? = getParcelableArrayList(key)
-inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String?): T? = getParcelableExtra(key)
+inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String?): T? = BundleCompat.getParcelable(this, key, T::class.java)
+inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String?): ArrayList<T>? = BundleCompat.getParcelableArrayList(this, key, T::class.java)
+inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String?): T? = IntentCompat.getParcelableExtra(this, key, T::class.java)

--- a/app/src/main/java/com/hippo/ehviewer/util/ParcelableCompat.kt
+++ b/app/src/main/java/com/hippo/ehviewer/util/ParcelableCompat.kt
@@ -3,9 +3,11 @@ package com.hippo.ehviewer.util
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import android.util.SparseArray
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String?): T? = BundleCompat.getParcelable(this, key, T::class.java)
 inline fun <reified T : Parcelable> Bundle.getParcelableArrayListCompat(key: String?): ArrayList<T>? = BundleCompat.getParcelableArrayList(this, key, T::class.java)
+inline fun <reified T : Parcelable> Bundle.getSparseParcelableArrayCompat(key: String?): SparseArray<T>? = BundleCompat.getSparseParcelableArray(this, key, T::class.java)
 inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String?): T? = IntentCompat.getParcelableExtra(this, key, T::class.java)


### PR DESCRIPTION
This reverts commit 576ff1b0.

Reason for revert: Fixed in `androidx.core:core:1.12.0-beta01`.
https://android.googlesource.com/platform/frameworks/support/+/8f7e02550620919fafb4c7fef8743f8c20562945